### PR TITLE
Update the sample in the vignette

### DIFF
--- a/vignettes/sample.txt
+++ b/vignettes/sample.txt
@@ -2,7 +2,7 @@
 name: Mitchell O'Hara-Wild
 date: "`r format(Sys.time(), '%B, %Y')`"
 profilepic: pic.jpg
-website: mitchelloharawild.com
+www: mitchelloharawild.com
 github: mitchelloharawild
 linkedin: mitchelloharawild
 twitter: mitchoharawild


### PR DESCRIPTION
Sample awesome-cv template had website: url in the options but this did not show up in the knitted file. I looked through the .tex template and found that it should be www: url. No change was needed to the .tex file just to the sample so that a user would know how to specify it properly.