### PR TITLE
Add GitHub URL to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Suggests:
 License: GPL-3
 Encoding: UTF-8
 BugReports: https://github.com/ropenscilabs/vitae/issues
-URL: https://docs.ropensci.org/vitae/
+URL: https://docs.ropensci.org/vitae/, https://github.com/ropenscilabs/vitae
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets=c('rd', 'collate', 'namespace'))
 RoxygenNote: 6.1.1


### PR DESCRIPTION
This allows pkgdown to create a link to the repo.

More info on the [pkgdown website](https://pkgdown.r-lib.org/articles/pkgdown.html#navigation-bar)