### PR TITLE
#70 Tackle biblatex Warning

### DIFF
--- a/inst/bib_format.tex
+++ b/inst/bib_format.tex
@@ -45,7 +45,7 @@
 % Counters for keeping track of papers
 \newcounter{papers}
 
-\DeclareSortingScheme{ty}{
+\DeclareSortingTemplate{ty}{
   \sort{
     \field{title}
   }


### PR DESCRIPTION
This PR addresses the `Package biblatex Warning: '\DeclareSortingScheme' is deprecated.`