### PR TITLE
markdowncv now calls html_document(theme = NULL)

### DIFF
--- a/R/markdowncv.R
+++ b/R/markdowncv.R
@@ -28,7 +28,14 @@ markdowncv <- function(..., theme = c("kjhealy", "blmoore", "davewhipp", "ccbaum
   copy_supporting_files("markdowncv")
   cv_document(..., pandoc_vars = list(theme = theme), mathjax = NULL,
               template = template,
-              base_format = rmarkdown::html_document)
+              base_format = html_document_notheme)
+}
+
+#' wrapper to set theme = NULL for html_document
+#' so that it doesn't fight the theme argument of markdowncv in the final pandoc render
+#' @keywords internal
+html_document_notheme <- function (...) {
+  rmarkdown::html_document(theme = NULL, ...)
 }
 
 


### PR DESCRIPTION
A patch for the markdowncv theme to construct the theme CSS file name in inst/rmarkdown/templates/markdowncv/skeleton/media/ correctly, without appending "bootstrap" to the theme name. 

Commit f32ca0b , which solved an issue with the CV body being duplicated when rendering, changed the way in which vitae-specific YAML-to-pandoc args were getting merged with the underlying `rmarkdown::XYZ_document` default pandoc args by `rmarkdown::merge_output_formats()`. While I'm not exactly sure WHY the behavior changed, it did, and two theme values were getting output into the pandoc render: `theme: kjhealy` (or any markdowncv theme), and `theme: bootstrap` (the default from `rmarkdown::html_document()`). Pandoc was then concatenating these two theme variables together, looking for the theme "kjhealybootstrap" instead of just "kjhealy".

This patch does not modify `cv_document()` at all, but rather changes `markdowncv()` to use `rmarkdown::html_document(theme=NULL)` as the base_format for `cv_document()`, sidestepping the failure to deduplicate pandoc args.

Closes #261 I believe!